### PR TITLE
Reuse generated order number across order creation flow

### DIFF
--- a/service/order/src/main/java/com/nahid/order/service/ProductPurchaseService.java
+++ b/service/order/src/main/java/com/nahid/order/service/ProductPurchaseService.java
@@ -5,7 +5,7 @@ import com.nahid.order.dto.response.PurchaseProductResponseDto;
 
 public interface ProductPurchaseService {
 
-    PurchaseProductResponseDto purchaseProducts(CreateOrderRequest request);
+    PurchaseProductResponseDto purchaseProducts(CreateOrderRequest request, String orderReference);
     String formatPurchaseError(PurchaseProductResponseDto response);
 }
 

--- a/service/order/src/main/java/com/nahid/order/service/impl/OrderServiceImpl.java
+++ b/service/order/src/main/java/com/nahid/order/service/impl/OrderServiceImpl.java
@@ -46,14 +46,16 @@ public class OrderServiceImpl implements OrderService {
         try {
             userValidationService.validateUserForOrder(request.getUserId());
 
-            PurchaseProductResponseDto purchaseResponse = productPurchaseService.purchaseProducts(request);
+            String orderNumber = orderNumberService.generateOrderNumber();
+
+            PurchaseProductResponseDto purchaseResponse = productPurchaseService.purchaseProducts(request, orderNumber);
 
             if (purchaseResponse == null || !purchaseResponse.isSuccess()) {
                 String errorMessage = productPurchaseService.formatPurchaseError(purchaseResponse);
                 throw new OrderProcessingException(String.format(ExceptionMessageConstant.PRODUCT_PURCHASE_FAILED, errorMessage));
             }
             Order order = orderMapper.toEntity(request);
-            order.setOrderNumber(orderNumberService.generateOrderNumber());
+            order.setOrderNumber(orderNumber);
             order.setStatus(OrderStatus.PENDING);
 
             List<OrderItem> orderItems = request.getOrderItems().stream()

--- a/service/order/src/main/java/com/nahid/order/service/impl/ProductPurchaseServiceImpl.java
+++ b/service/order/src/main/java/com/nahid/order/service/impl/ProductPurchaseServiceImpl.java
@@ -5,7 +5,6 @@ import com.nahid.order.dto.request.CreateOrderRequest;
 import com.nahid.order.dto.request.PurchaseProductItemDto;
 import com.nahid.order.dto.request.PurchaseProductRequestDto;
 import com.nahid.order.dto.response.PurchaseProductResponseDto;
-import com.nahid.order.service.OrderNumberService;
 import com.nahid.order.service.ProductPurchaseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,12 +19,9 @@ import java.util.stream.Collectors;
 public class ProductPurchaseServiceImpl implements ProductPurchaseService {
 
     private final ProductClient productClient;
-    private final OrderNumberService orderNumberService;
 
     @Override
-    public PurchaseProductResponseDto purchaseProducts(CreateOrderRequest request) {
-        String orderReference = orderNumberService.generateOrderNumber();
-
+    public PurchaseProductResponseDto purchaseProducts(CreateOrderRequest request, String orderReference) {
         List<PurchaseProductItemDto> items = request.getOrderItems().stream()
                 .map(item -> PurchaseProductItemDto.builder()
                         .productId(item.getProductId())


### PR DESCRIPTION
## Summary
- generate the order number once in the order service and reuse it for product reservation and persistence
- adjust the product purchase service API to accept an order reference and populate the downstream request

## Testing
- mvn -q test *(fails: Non-resolvable parent POM due to 403 when resolving Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68de76eb47c883208ff56f8cbde9d70f