### PR TITLE
chore: streamline product logging setup

### DIFF
--- a/service/product/pom.xml
+++ b/service/product/pom.xml
@@ -40,10 +40,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-aop</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>

--- a/service/product/src/main/java/com/nahid/product/controller/CategoryController.java
+++ b/service/product/src/main/java/com/nahid/product/controller/CategoryController.java
@@ -8,7 +8,6 @@ import com.nahid.product.util.constant.ApiResponseConstant;
 import com.nahid.product.util.helper.ApiResponseUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,42 +17,36 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
-@Slf4j
 public class CategoryController {
 
     private final CategoryService categoryService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CategoryResponseDto>> createCategory(@Valid @RequestBody CreateCategoryRequestDto request) {
-        log.info("Received request to create category with name: {}", request.getName());
         CategoryResponseDto response = categoryService.createCategory(request);
         return ApiResponseUtil.success(response, ApiResponseConstant.CATEGORY_CREATED_SUCCESSFULLY, HttpStatus.CREATED);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<CategoryResponseDto>> getCategoryById(@PathVariable Long id) {
-        log.info("Received request to get category with ID: {}", id);
         CategoryResponseDto response = categoryService.getCategoryById(id);
         return ApiResponseUtil.success(response, ApiResponseConstant.CATEGORY_FETCHED_SUCCESSFULLY);
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<CategoryResponseDto>>> getAllCategories() {
-        log.info("Received request to get all categories");
         List<CategoryResponseDto> response = categoryService.getAllCategories();
         return ApiResponseUtil.success(response, ApiResponseConstant.CATEGORIES_FETCHED_SUCCESSFULLY);
     }
 
     @GetMapping("/active")
     public ResponseEntity<ApiResponse<List<CategoryResponseDto>>> getActiveCategories() {
-        log.info("Received request to get active categories");
         List<CategoryResponseDto> response = categoryService.getActiveCategories();
         return ApiResponseUtil.success(response, ApiResponseConstant.ACTIVE_CATEGORIES_FETCHED_SUCCESSFULLY);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable Long id) {
-        log.info("Received request to delete category with ID: {}", id);
         categoryService.deleteCategory(id);
         return ApiResponseUtil.success(null, ApiResponseConstant.CATEGORY_DELETED_SUCCESSFULLY, HttpStatus.NO_CONTENT);
     }

--- a/service/product/src/main/java/com/nahid/product/controller/ProductController.java
+++ b/service/product/src/main/java/com/nahid/product/controller/ProductController.java
@@ -7,7 +7,6 @@ import com.nahid.product.util.constant.ApiResponseConstant;
 import com.nahid.product.util.helper.ApiResponseUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,21 +21,18 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/products")
 @RequiredArgsConstructor
-@Slf4j
 public class ProductController {
 
     private final ProductService productService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<ProductResponseDto>> createProduct(@Valid @RequestBody CreateProductRequestDto request) {
-        log.info("Received request to create product with SKU: {}", request.getSku());
         ProductResponseDto response = productService.createProduct(request);
         return ApiResponseUtil.success(response, ApiResponseConstant.PRODUCT_CREATED_SUCCESSFULLY, HttpStatus.CREATED);
     }
 
     @PostMapping("/purchase")
     public ResponseEntity<ApiResponse<PurchaseProductResponseDto>> purchaseProduct(@Valid @RequestBody PurchaseProductRequestDto request) {
-        log.info("Received purchase request for order reference: {}", request.getOrderReference());
         PurchaseProductResponseDto response = productService.processPurchase(request);
         HttpStatus status = response.isSuccess() ? HttpStatus.OK : HttpStatus.CONFLICT;
         if (response.isSuccess()) {
@@ -47,14 +43,12 @@ public class ProductController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<ProductResponseDto>> getProductById(@PathVariable Long id) {
-        log.info("Received request to get product with ID: {}", id);
         ProductResponseDto response = productService.getProductById(id);
         return ApiResponseUtil.success(response, ApiResponseConstant.PRODUCT_FETCHED_SUCCESSFULLY);
     }
 
     @GetMapping("/sku/{sku}")
     public ResponseEntity<ApiResponse<ProductResponseDto>> getProductBySku(@PathVariable String sku) {
-        log.info("Received request to get product with SKU: {}", sku);
         ProductResponseDto response = productService.getProductBySku(sku);
         return ApiResponseUtil.success(response, ApiResponseConstant.PRODUCT_FETCHED_SUCCESSFULLY);
     }
@@ -77,7 +71,6 @@ public class ProductController {
     public ResponseEntity<ApiResponse<Page<ProductResponseDto>>> getProductsByCategory(
             @PathVariable Long categoryId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        log.info("Received request to get products by category ID: {} with pagination: {}", categoryId, pageable);
         Page<ProductResponseDto> response = productService.getProductsByCategory(categoryId, pageable);
         return ApiResponseUtil.success(response, ApiResponseConstant.PRODUCTS_BY_CATEGORY_FETCHED);
     }
@@ -90,21 +83,18 @@ public class ProductController {
             @RequestParam(required = false) BigDecimal maxPrice,
             @RequestParam(required = false) Long categoryId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        log.info("Received request to search products with filters");
         Page<ProductResponseDto> response = productService.searchProducts(name, brand, minPrice, maxPrice, categoryId, pageable);
         return ApiResponseUtil.success(response, ApiResponseConstant.PRODUCTS_SEARCHED_SUCCESSFULLY);
     }
 
     @GetMapping("/featured")
     public ResponseEntity<ApiResponse<List<ProductResponseDto>>> getFeaturedProducts() {
-        log.info("Received request to get featured products");
         List<ProductResponseDto> response = productService.getFeaturedProducts();
         return ApiResponseUtil.success(response, ApiResponseConstant.FEATURED_PRODUCTS_FETCHED);
     }
 
     @GetMapping("/low-stock")
     public ResponseEntity<ApiResponse<List<ProductResponseDto>>> getLowStockProducts() {
-        log.info("Received request to get low stock products");
         List<ProductResponseDto> response = productService.getLowStockProducts();
         return ApiResponseUtil.success(response, ApiResponseConstant.LOW_STOCK_PRODUCTS_FETCHED);
     }
@@ -113,14 +103,12 @@ public class ProductController {
     public ResponseEntity<ApiResponse<ProductResponseDto>> updateProduct(
             @PathVariable Long id,
             @Valid @RequestBody UpdateProductRequestDto request) {
-        log.info("Received request to update product with ID: {}", id);
         ProductResponseDto response = productService.updateProduct(id, request);
         return ApiResponseUtil.success(response, ApiResponseConstant.PRODUCT_UPDATED_SUCCESSFULLY);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteProduct(@PathVariable Long id) {
-        log.info("Received request to delete product with ID: {}", id);
         productService.deleteProduct(id);
         return ApiResponseUtil.success(null, ApiResponseConstant.PRODUCT_DELETED_SUCCESSFULLY, HttpStatus.NO_CONTENT);
     }
@@ -129,7 +117,6 @@ public class ProductController {
     public ResponseEntity<ApiResponse<ProductResponseDto>> updateStock(
             @PathVariable Long id,
             @RequestParam Integer stock) {
-        log.info("Received request to update stock for product ID: {} to quantity: {}", id, stock);
         ProductResponseDto response = productService.updateStock(id, stock);
         return ApiResponseUtil.success(response, ApiResponseConstant.PRODUCT_STOCK_UPDATED_SUCCESSFULLY);
     }
@@ -138,7 +125,6 @@ public class ProductController {
     public ResponseEntity<ApiResponse<Boolean>> checkProductAvailability(
             @PathVariable Long id,
             @RequestParam Integer quantity) {
-        log.info("Received request to check availability for product ID: {} with quantity: {}", id, quantity);
         boolean isAvailable = productService.isProductAvailable(id, quantity);
         return ApiResponseUtil.success(isAvailable, ApiResponseConstant.PRODUCT_AVAILABILITY_CHECKED);
     }

--- a/service/product/src/main/java/com/nahid/product/logging/LoggingAspect.java
+++ b/service/product/src/main/java/com/nahid/product/logging/LoggingAspect.java
@@ -1,0 +1,71 @@
+package com.nahid.product.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    @Pointcut("within(com.nahid.product.controller..*)")
+    public void controllerMethods() {
+        // Pointcut for controller methods
+    }
+
+    @Around("controllerMethods()")
+    public Object logControllerMethods(ProceedingJoinPoint joinPoint) throws Throwable {
+        ServletRequestAttributes attributes = getServletRequestAttributes();
+        HttpServletRequest request = attributes != null ? attributes.getRequest() : null;
+        HttpServletResponse response = attributes != null ? attributes.getResponse() : null;
+
+        String method = request != null ? request.getMethod() : "UNKNOWN";
+        String uri = request != null ? request.getRequestURI() : joinPoint.getSignature().toShortString();
+
+        long startTime = System.currentTimeMillis();
+        try {
+            Object result = joinPoint.proceed();
+            int status = resolveStatus(result, response, null);
+            log.info("Completed {} {} with status {} in {} ms", method, uri, status, System.currentTimeMillis() - startTime);
+            return result;
+        } catch (Throwable ex) {
+            int status = resolveStatus(null, response, ex);
+            log.error("Error handling {} {} with status {} in {} ms: {}", method, uri, status,
+                    System.currentTimeMillis() - startTime, ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    ServletRequestAttributes getServletRequestAttributes() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes instanceof ServletRequestAttributes attributes) {
+            return attributes;
+        }
+        return null;
+    }
+
+    int resolveStatus(Object result, HttpServletResponse response, Throwable error) {
+        if (result instanceof ResponseEntity<?> responseEntity) {
+            return responseEntity.getStatusCode().value();
+        }
+        if (error instanceof ResponseStatusException responseStatusException) {
+            return responseStatusException.getStatusCode().value();
+        }
+        if (response != null && response.getStatus() > 0) {
+            return response.getStatus();
+        }
+        return error == null ? HttpStatus.OK.value() : HttpStatus.INTERNAL_SERVER_ERROR.value();
+    }
+}


### PR DESCRIPTION
## Summary
- remove controller-level info logs so the logging aspect owns request logging
- add the Spring AOP starter required to wire the logging aspect beans

## Testing
- `mvn test` *(fails: Maven Central returned HTTP 403 while downloading org.springframework.boot:spring-boot-starter-parent:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68dec686df588320951dceec1b88a92b