### PR TITLE
Refactor purchase reservation response handling

### DIFF
--- a/service/order/src/main/java/com/nahid/order/client/ProductFeignClientFallback.java
+++ b/service/order/src/main/java/com/nahid/order/client/ProductFeignClientFallback.java
@@ -9,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.util.Collections;
 
 @Component
 @Slf4j
@@ -21,18 +20,11 @@ public class ProductFeignClientFallback implements ProductClient {
         log.error("Fallback triggered for reserveInventory with orderReference: {}",
                 request != null ? request.getOrderReference() : "unknown");
 
-        PurchaseProductResponseDto responseDto = PurchaseProductResponseDto.builder()
-                .success(false)
-                .message("Product service is unavailable. Unable to reserve inventory.")
-                .orderReference(request != null ? request.getOrderReference() : null)
-                .items(Collections.emptyList())
-                .build();
-
         ApiResponse<PurchaseProductResponseDto> apiResponse = ApiResponse.<PurchaseProductResponseDto>builder()
                 .statusCode(HttpStatus.SERVICE_UNAVAILABLE.value())
                 .success(false)
-                .message(responseDto.getMessage())
-                .data(responseDto)
+                .message("Product service is unavailable. Unable to reserve inventory.")
+                .data(null)
                 .timestamp(Instant.now())
                 .build();
 

--- a/service/order/src/main/java/com/nahid/order/dto/response/PurchaseProductResponseDto.java
+++ b/service/order/src/main/java/com/nahid/order/dto/response/PurchaseProductResponseDto.java
@@ -13,8 +13,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PurchaseProductResponseDto {
-    private boolean success;
-    private String message;
     private String orderReference;
     private List<PurchaseProductItemResultDto> items;
 

--- a/service/order/src/main/java/com/nahid/order/service/ProductPurchaseService.java
+++ b/service/order/src/main/java/com/nahid/order/service/ProductPurchaseService.java
@@ -10,7 +10,5 @@ public interface ProductPurchaseService {
     void confirmReservation(String orderReference);
 
     void releaseReservation(String orderReference);
-
-    String formatReservationError(PurchaseProductResponseDto response);
 }
 

--- a/service/order/src/main/java/com/nahid/order/service/impl/OrderServiceImpl.java
+++ b/service/order/src/main/java/com/nahid/order/service/impl/OrderServiceImpl.java
@@ -51,10 +51,10 @@ public class OrderServiceImpl implements OrderService {
             orderNumber = orderNumberService.generateOrderNumber();
 
             PurchaseProductResponseDto reservationResponse = productPurchaseService.reserveProducts(request, orderNumber);
-
-            if (reservationResponse == null || !reservationResponse.isSuccess()) {
-                String errorMessage = productPurchaseService.formatReservationError(reservationResponse);
-                throw new OrderProcessingException(String.format(ExceptionMessageConstant.PRODUCT_RESERVATION_FAILED, errorMessage));
+            if (reservationResponse == null) {
+                throw new OrderProcessingException(String.format(
+                        ExceptionMessageConstant.PRODUCT_RESERVATION_FAILED,
+                        "Product service returned empty reservation data"));
             }
             reservationCreated = true;
 

--- a/service/product/src/main/java/com/nahid/product/controller/ProductController.java
+++ b/service/product/src/main/java/com/nahid/product/controller/ProductController.java
@@ -38,8 +38,7 @@ public class ProductController {
     @PostMapping("/inventory/reservations")
     public ResponseEntity<ApiResponse<PurchaseProductResponseDto>> reserveInventory(@Valid @RequestBody PurchaseProductRequestDto request) {
         PurchaseProductResponseDto response = productService.reserveInventory(request);
-        HttpStatus status = response.isSuccess() ? HttpStatus.OK : HttpStatus.CONFLICT;
-        return ApiResponseUtil.success(response, ApiResponseConstant.INVENTORY_RESERVED_SUCCESSFULLY , status);
+        return ApiResponseUtil.success(response, ApiResponseConstant.INVENTORY_RESERVED_SUCCESSFULLY, HttpStatus.OK);
     }
 
     @PostMapping("/inventory/reservations/{orderReference}/confirm")

--- a/service/product/src/main/java/com/nahid/product/dto/response/PurchaseProductResponseDto.java
+++ b/service/product/src/main/java/com/nahid/product/dto/response/PurchaseProductResponseDto.java
@@ -12,8 +12,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PurchaseProductResponseDto {
-    private boolean success;
-    private String message;
     private String orderReference;
     private List<PurchaseProductItemResultDto> items;
 

--- a/service/product/src/main/java/com/nahid/product/exception/GlobalExceptionHandler.java
+++ b/service/product/src/main/java/com/nahid/product/exception/GlobalExceptionHandler.java
@@ -31,6 +31,12 @@ public class GlobalExceptionHandler {
         return ApiResponseUtil.failureWithHttpStatus(ex.getMessage(), HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(PurchaseException.class)
+    public ResponseEntity<ApiResponse<Object>> handlePurchaseException(PurchaseException ex) {
+        log.error("Purchase operation failed: {}", ex.getMessage());
+        return ApiResponseUtil.failureWithHttpStatus(ex.getMessage(), HttpStatus.CONFLICT);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         log.error("Validation failed: {}", ex.getMessage());

--- a/service/product/src/main/java/com/nahid/product/util/constant/ExceptionMessageConstant.java
+++ b/service/product/src/main/java/com/nahid/product/util/constant/ExceptionMessageConstant.java
@@ -1,0 +1,10 @@
+package com.nahid.product.util.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ExceptionMessageConstant {
+
+    public static final String PRODUCT_RESERVATION_FAILED = "Product reservation failed: %s";
+}


### PR DESCRIPTION
## Summary
- remove duplicated success/message fields from purchase reservation response DTOs in product and order services
- throw purchase-specific exceptions with standardized product reservation failure messages and expose them through the global handler
- update order service client logic and fallback handling to rely on ApiResponse metadata and fail fast on unsuccessful reservations
