### PR TITLE
Remove redundant product price lookups during order creation

### DIFF
--- a/service/order/src/main/java/com/nahid/order/client/ProductFeignClientFallback.java
+++ b/service/order/src/main/java/com/nahid/order/client/ProductFeignClientFallback.java
@@ -9,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-
 @Component
 @Slf4j
 public class ProductFeignClientFallback implements ProductClient {

--- a/service/order/src/main/java/com/nahid/order/dto/request/CreateOrderItemRequest.java
+++ b/service/order/src/main/java/com/nahid/order/dto/request/CreateOrderItemRequest.java
@@ -1,6 +1,5 @@
 ﻿package com.nahid.order.dto.request;
 
-import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -8,9 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.math.BigDecimal;
-import java.util.UUID;
 
 @Data
 @Builder
@@ -31,7 +27,4 @@ public class CreateOrderItemRequest {
     @Min(value = 1, message = "Quantity must be at least 1")
     private Integer quantity;
 
-    @NotNull(message = "Unit price is required")
-    @DecimalMin(value = "0.01", message = "Unit price must be greater than 0")
-    private BigDecimal unitPrice;
 }

--- a/service/order/src/main/java/com/nahid/order/mapper/OrderMapper.java
+++ b/service/order/src/main/java/com/nahid/order/mapper/OrderMapper.java
@@ -29,6 +29,9 @@ public interface OrderMapper {
 
     @Mapping(target = "orderItemId", ignore = true)
     @Mapping(target = "order", ignore = true)
+    @Mapping(target = "productName", ignore = true)
+    @Mapping(target = "productSku", ignore = true)
+    @Mapping(target = "unitPrice", ignore = true)
     @Mapping(target = "totalPrice", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     OrderItem toEntity(CreateOrderItemRequest request);

--- a/service/order/src/main/java/com/nahid/order/service/impl/ProductPurchaseServiceImpl.java
+++ b/service/order/src/main/java/com/nahid/order/service/impl/ProductPurchaseServiceImpl.java
@@ -61,6 +61,12 @@ public class ProductPurchaseServiceImpl implements ProductPurchaseService {
                     "Product service returned empty reservation data"));
         }
 
+        if (responseData.getItems() == null || responseData.getItems().isEmpty()) {
+            throw new OrderProcessingException(String.format(
+                    ExceptionMessageConstant.PRODUCT_RESERVATION_FAILED,
+                    "Product service returned empty reservation items"));
+        }
+
         return responseData;
     }
 

--- a/service/order/src/main/java/com/nahid/order/util/constant/ExceptionMessageConstant.java
+++ b/service/order/src/main/java/com/nahid/order/util/constant/ExceptionMessageConstant.java
@@ -34,4 +34,5 @@ public class ExceptionMessageConstant {
 
     // Product-related Exception Messages
     public static final String PRODUCT_RESERVATION_FAILED = "Product reservation failed: %s";
+    public static final String PRODUCT_PRICE_FETCH_FAILED = "Product price lookup failed: %s";
 }

--- a/service/product/src/main/java/com/nahid/product/controller/ProductController.java
+++ b/service/product/src/main/java/com/nahid/product/controller/ProductController.java
@@ -20,7 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/products")

--- a/service/product/src/main/java/com/nahid/product/entity/InventoryReservationItem.java
+++ b/service/product/src/main/java/com/nahid/product/entity/InventoryReservationItem.java
@@ -31,9 +31,4 @@ public class InventoryReservationItem {
     @Column(name = "unit_price", precision = 12, scale = 2)
     private BigDecimal unitPrice;
 
-    @Column(name = "product_name")
-    private String productName;
-
-    @Column(name = "sku")
-    private String sku;
 }

--- a/service/product/src/main/java/com/nahid/product/service/impl/ProductServiceImpl.java
+++ b/service/product/src/main/java/com/nahid/product/service/impl/ProductServiceImpl.java
@@ -28,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.List;
 
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -194,4 +193,5 @@ public class ProductServiceImpl implements ProductService {
     public void releaseReservation(String orderReference) {
         purchaseService.releaseReservation(orderReference);
     }
+
 }

--- a/service/product/src/main/java/com/nahid/product/util/constant/ApiResponseConstant.java
+++ b/service/product/src/main/java/com/nahid/product/util/constant/ApiResponseConstant.java
@@ -22,7 +22,6 @@ public final class ApiResponseConstant {
     public static final String INVENTORY_RESERVATION_FAILED = "Inventory reservation could not be completed";
     public static final String INVENTORY_RESERVATION_CONFIRMED = "Inventory reservation confirmed";
     public static final String INVENTORY_RESERVATION_RELEASED = "Inventory reservation released";
-
     public static final String CATEGORY_CREATED_SUCCESSFULLY = "Category created successfully";
     public static final String CATEGORY_FETCHED_SUCCESSFULLY = "Category fetched successfully";
     public static final String CATEGORIES_FETCHED_SUCCESSFULLY = "Categories fetched successfully";

--- a/service/product/src/main/resources/db/migration/V2__Simplify_inventory_reservation_items.sql
+++ b/service/product/src/main/resources/db/migration/V2__Simplify_inventory_reservation_items.sql
@@ -1,0 +1,3 @@
+ALTER TABLE inventory_reservation_items
+    DROP COLUMN IF EXISTS product_name,
+    DROP COLUMN IF EXISTS sku;


### PR DESCRIPTION
## Summary
- rely on reservation responses for authoritative pricing when creating orders and validate reservation data before persisting
- clean up product service contracts by removing the unused bulk pricing DTOs/endpoints and associated client plumbing
- add additional guards in the order service product purchase adapter to surface empty reservation responses early

