### PR TITLE
Generalize base entities to hold typed identifiers

### DIFF
--- a/service/notification/src/main/java/com/nahid/notification/entity/BaseEntity.java
+++ b/service/notification/src/main/java/com/nahid/notification/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.nahid.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class BaseEntity<T> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private T id;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/service/notification/src/main/java/com/nahid/notification/entity/Notification.java
+++ b/service/notification/src/main/java/com/nahid/notification/entity/Notification.java
@@ -3,12 +3,14 @@ package com.nahid.notification.entity;
 import com.nahid.notification.enums.NotificationStatus;
 import com.nahid.notification.enums.NotificationType;
 import com.nahid.notification.enums.ReferenceType;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -19,11 +21,7 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class Notification {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+public class Notification extends BaseEntity<UUID> {
 
     @Column(name = "reference_id", nullable = false)
     private UUID referenceId; // paymentId or orderId
@@ -69,14 +67,4 @@ public class Notification {
 
     @Column(name = "retry_count")
     private Integer retryCount = 0;
-
-    @CreationTimestamp
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-
 }

--- a/service/order/src/main/java/com/nahid/order/entity/BaseEntity.java
+++ b/service/order/src/main/java/com/nahid/order/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.nahid.order.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class BaseEntity<T> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private T id;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/service/order/src/main/java/com/nahid/order/entity/Order.java
+++ b/service/order/src/main/java/com/nahid/order/entity/Order.java
@@ -1,14 +1,25 @@
 package com.nahid.order.entity;
 
 import com.nahid.order.enums.OrderStatus;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -20,14 +31,10 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
-
-public class Order {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "order_id")
-    private UUID orderId;
-
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "order_id"))
+})
+public class Order extends BaseEntity<UUID> {
 
     @Column(name = "order_number", nullable = false, unique = true)
     private String orderNumber;
@@ -52,16 +59,13 @@ public class Order {
     @Builder.Default
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    public UUID getOrderId() {
+        return getId();
+    }
 
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Version
-    private Long version;
+    public void setOrderId(UUID orderId) {
+        setId(orderId);
+    }
 
     // Helper methods
     public void addOrderItem(OrderItem orderItem) {

--- a/service/order/src/main/java/com/nahid/order/entity/OrderItem.java
+++ b/service/order/src/main/java/com/nahid/order/entity/OrderItem.java
@@ -1,12 +1,22 @@
 package com.nahid.order.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Index;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import org.hibernate.annotations.CreationTimestamp;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -19,13 +29,10 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
-
-public class OrderItem {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "order_item_id")
-    private UUID orderItemId;
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "order_item_id"))
+})
+public class OrderItem extends BaseEntity<UUID> {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false)
@@ -49,7 +56,11 @@ public class OrderItem {
     @Column(name = "total_price", nullable = false, precision = 10, scale = 2)
     private BigDecimal totalPrice;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    public UUID getOrderItemId() {
+        return getId();
+    }
+
+    public void setOrderItemId(UUID orderItemId) {
+        setId(orderItemId);
+    }
 }

--- a/service/payment/src/main/java/com/nahid/payment/entity/BaseEntity.java
+++ b/service/payment/src/main/java/com/nahid/payment/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.nahid.payment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class BaseEntity<T> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private T id;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/service/payment/src/main/java/com/nahid/payment/entity/Payment.java
+++ b/service/payment/src/main/java/com/nahid/payment/entity/Payment.java
@@ -2,13 +2,16 @@ package com.nahid.payment.entity;
 
 import com.nahid.payment.enums.PaymentMethod;
 import com.nahid.payment.enums.PaymentStatus;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -25,11 +28,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Payment {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+public class Payment extends BaseEntity<UUID> {
 
     @Column(name = "order_id", nullable = false)
     private UUID orderId;
@@ -69,15 +68,6 @@ public class Payment {
     @Column(name = "failure_reason")
     private String failureReason;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     @Column(name = "processed_at")
     private LocalDateTime processedAt;
-
 }

--- a/service/product/src/main/java/com/nahid/product/entity/BaseEntity.java
+++ b/service/product/src/main/java/com/nahid/product/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.nahid.product.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class BaseEntity<T> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private T id;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/service/product/src/main/java/com/nahid/product/entity/Category.java
+++ b/service/product/src/main/java/com/nahid/product/entity/Category.java
@@ -3,10 +3,7 @@ package com.nahid.product.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -17,11 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class Category {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+public class Category extends BaseEntity<Long> {
 
     @Column(nullable = false, unique = true, length = 100)
     String name;
@@ -35,11 +28,4 @@ public class Category {
     @OneToMany(mappedBy = "category", fetch = FetchType.LAZY)
     List<Product> products;
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    LocalDateTime updatedAt;
 }

--- a/service/product/src/main/java/com/nahid/product/entity/InventoryReservation.java
+++ b/service/product/src/main/java/com/nahid/product/entity/InventoryReservation.java
@@ -3,8 +3,6 @@ package com.nahid.product.entity;
 import com.nahid.product.enums.ReservationStatus;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -18,11 +16,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class InventoryReservation {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class InventoryReservation extends BaseEntity<Long> {
 
     @Column(name = "reservation_code", nullable = false, unique = true)
     private String reservationCode;
@@ -36,14 +30,6 @@ public class InventoryReservation {
 
     @Column(name = "expires_at")
     private LocalDateTime expiresAt;
-
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<InventoryReservationItem> items = new ArrayList<>();

--- a/service/product/src/main/java/com/nahid/product/entity/InventoryReservationItem.java
+++ b/service/product/src/main/java/com/nahid/product/entity/InventoryReservationItem.java
@@ -12,11 +12,7 @@ import java.math.BigDecimal;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class InventoryReservationItem {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class InventoryReservationItem extends BaseEntity<Long> {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", nullable = false)

--- a/service/product/src/main/java/com/nahid/product/entity/Product.java
+++ b/service/product/src/main/java/com/nahid/product/entity/Product.java
@@ -2,12 +2,8 @@ package com.nahid.product.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.FieldDefaults;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "products")
@@ -15,11 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Product {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Product extends BaseEntity<Long> {
 
     @Column(nullable = false)
     private String name;
@@ -57,15 +49,6 @@ public class Product {
 
     @Column(name = "images_url")
     private String imageUrl;
-
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)

--- a/service/user/src/main/java/com/nahid/userservice/entity/BaseEntity.java
+++ b/service/user/src/main/java/com/nahid/userservice/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.nahid.userservice.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class BaseEntity<T> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private T id;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/service/user/src/main/java/com/nahid/userservice/entity/RefreshToken.java
+++ b/service/user/src/main/java/com/nahid/userservice/entity/RefreshToken.java
@@ -12,11 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class RefreshToken {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class RefreshToken extends BaseEntity<Long> {
 
     @Column(unique = true, nullable = false)
     private String token;
@@ -30,9 +26,6 @@ public class RefreshToken {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
-    @Builder.Default
-    private LocalDateTime createdAt = LocalDateTime.now();
 
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expiryDate);

--- a/service/user/src/main/java/com/nahid/userservice/entity/User.java
+++ b/service/user/src/main/java/com/nahid/userservice/entity/User.java
@@ -9,13 +9,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
@@ -26,10 +23,7 @@ import java.util.List;
 @Setter
 @Getter
 @AllArgsConstructor
-public class User implements UserDetails {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class User extends BaseEntity<Long> implements UserDetails {
 
     @Column(unique = true, nullable = false)
     @Email(message = "Email should be valid")
@@ -76,14 +70,6 @@ public class User implements UserDetails {
 
     @Builder.Default
     private boolean credentialsNonExpired = true;
-
-    @Column(name = "created_at")
-    @CreationTimestamp
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    @UpdateTimestamp
-    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<UserAddress> addresses;

--- a/service/user/src/main/java/com/nahid/userservice/entity/UserAddress.java
+++ b/service/user/src/main/java/com/nahid/userservice/entity/UserAddress.java
@@ -11,10 +11,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserAddress {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class UserAddress extends BaseEntity<Long> {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)


### PR DESCRIPTION
## Summary
- parameterize the product service BaseEntity identifier so entities can declare their id type
- do the same for the user service BaseEntity and update dependent entities to extend BaseEntity<Long>
- add typed identifier fields to the order, payment, and notification base entities and update their aggregates to inherit the ids instead of declaring them locally

