### PR TITLE
feat(order): add saga orchestrator for order creation

### DIFF
--- a/service/order/src/main/java/com/nahid/order/saga/ConfirmReservationCommand.java
+++ b/service/order/src/main/java/com/nahid/order/saga/ConfirmReservationCommand.java
@@ -1,0 +1,24 @@
+package com.nahid.order.saga;
+
+import com.nahid.order.service.ProductPurchaseService;
+
+public class ConfirmReservationCommand implements SagaCommand {
+
+    private final ProductPurchaseService productPurchaseService;
+    private final OrderSagaContext context;
+
+    public ConfirmReservationCommand(ProductPurchaseService productPurchaseService, OrderSagaContext context) {
+        this.productPurchaseService = productPurchaseService;
+        this.context = context;
+    }
+
+    @Override
+    public void execute() {
+        productPurchaseService.confirmReservation(context.getOrderNumber());
+    }
+
+    @Override
+    public void compensate() {
+        // no-op: reservation release handled by earlier steps
+    }
+}

--- a/service/order/src/main/java/com/nahid/order/saga/OrderSagaContext.java
+++ b/service/order/src/main/java/com/nahid/order/saga/OrderSagaContext.java
@@ -1,0 +1,26 @@
+package com.nahid.order.saga;
+
+import com.nahid.order.dto.request.CreateOrderRequest;
+import com.nahid.order.dto.response.PurchaseProductResponseDto;
+import com.nahid.order.entity.Order;
+import com.nahid.order.entity.OrderItem;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class OrderSagaContext {
+
+    private final CreateOrderRequest request;
+    private final String orderNumber;
+    private PurchaseProductResponseDto reservationResponse;
+    private Order savedOrder;
+    private List<OrderItem> orderItems;
+
+    public OrderSagaContext(CreateOrderRequest request, String orderNumber) {
+        this.request = request;
+        this.orderNumber = orderNumber;
+    }
+}

--- a/service/order/src/main/java/com/nahid/order/saga/PersistOrderCommand.java
+++ b/service/order/src/main/java/com/nahid/order/saga/PersistOrderCommand.java
@@ -1,0 +1,74 @@
+package com.nahid.order.saga;
+
+import com.nahid.order.dto.response.PurchaseProductItemResultDto;
+import com.nahid.order.dto.response.PurchaseProductResponseDto;
+import com.nahid.order.entity.Order;
+import com.nahid.order.entity.OrderItem;
+import com.nahid.order.enums.OrderStatus;
+import com.nahid.order.mapper.OrderMapper;
+import com.nahid.order.repository.OrderRepository;
+import com.nahid.order.service.OrderItemFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class PersistOrderCommand implements SagaCommand {
+
+    private final OrderRepository orderRepository;
+    private final OrderMapper orderMapper;
+    private final OrderItemFactory orderItemFactory;
+    private final OrderSagaContext context;
+
+    public PersistOrderCommand(
+            OrderRepository orderRepository,
+            OrderMapper orderMapper,
+            OrderItemFactory orderItemFactory,
+            OrderSagaContext context
+    ) {
+        this.orderRepository = orderRepository;
+        this.orderMapper = orderMapper;
+        this.orderItemFactory = orderItemFactory;
+        this.context = context;
+    }
+
+    @Override
+    public void execute() {
+        PurchaseProductResponseDto reservationResponse = context.getReservationResponse();
+        Map<Long, PurchaseProductItemResultDto> reservedItemsMap = reservationResponse.getItems()
+                .stream()
+                .collect(Collectors.toMap(
+                        PurchaseProductItemResultDto::getProductId,
+                        Function.identity(),
+                        (existing, replacement) -> existing));
+
+        Order order = orderMapper.toEntity(context.getRequest());
+        order.setOrderNumber(context.getOrderNumber());
+        order.setStatus(OrderStatus.PENDING);
+
+        List<OrderItem> orderItems = orderItemFactory.createOrderItems(
+                context.getRequest().getOrderItems(),
+                reservedItemsMap);
+
+        BigDecimal totalAmount = orderItems.stream()
+                .map(OrderItem::getTotalPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        order.setTotalAmount(totalAmount);
+        orderItems.forEach(order::addOrderItem);
+
+        Order savedOrder = orderRepository.save(order);
+        context.setOrderItems(orderItems);
+        context.setSavedOrder(savedOrder);
+    }
+
+    @Override
+    public void compensate() {
+        Order savedOrder = context.getSavedOrder();
+        if (savedOrder != null) {
+            orderRepository.delete(savedOrder);
+        }
+    }
+}

--- a/service/order/src/main/java/com/nahid/order/saga/ReserveProductsCommand.java
+++ b/service/order/src/main/java/com/nahid/order/saga/ReserveProductsCommand.java
@@ -1,0 +1,36 @@
+package com.nahid.order.saga;
+
+import com.nahid.order.dto.response.PurchaseProductResponseDto;
+import com.nahid.order.exception.OrderProcessingException;
+import com.nahid.order.service.ProductPurchaseService;
+import com.nahid.order.util.constant.ExceptionMessageConstant;
+
+public class ReserveProductsCommand implements SagaCommand {
+
+    private final ProductPurchaseService productPurchaseService;
+    private final OrderSagaContext context;
+
+    public ReserveProductsCommand(ProductPurchaseService productPurchaseService, OrderSagaContext context) {
+        this.productPurchaseService = productPurchaseService;
+        this.context = context;
+    }
+
+    @Override
+    public void execute() {
+        PurchaseProductResponseDto reservationResponse =
+                productPurchaseService.reserveProducts(context.getRequest(), context.getOrderNumber());
+
+        if (reservationResponse == null || reservationResponse.getItems() == null || reservationResponse.getItems().isEmpty()) {
+            throw new OrderProcessingException(String.format(
+                    ExceptionMessageConstant.PRODUCT_RESERVATION_FAILED,
+                    "Product service returned empty reservation data"));
+        }
+
+        context.setReservationResponse(reservationResponse);
+    }
+
+    @Override
+    public void compensate() {
+        productPurchaseService.releaseReservation(context.getOrderNumber());
+    }
+}

--- a/service/order/src/main/java/com/nahid/order/saga/SagaCommand.java
+++ b/service/order/src/main/java/com/nahid/order/saga/SagaCommand.java
@@ -1,0 +1,8 @@
+package com.nahid.order.saga;
+
+public interface SagaCommand {
+
+    void execute() throws Exception;
+
+    void compensate() throws Exception;
+}

--- a/service/order/src/main/java/com/nahid/order/saga/SagaManager.java
+++ b/service/order/src/main/java/com/nahid/order/saga/SagaManager.java
@@ -1,0 +1,38 @@
+package com.nahid.order.saga;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+public class SagaManager {
+
+    private final List<SagaCommand> commands = new ArrayList<>();
+    private final Deque<SagaCommand> executedCommands = new ArrayDeque<>();
+
+    public void addStep(SagaCommand command) {
+        commands.add(command);
+    }
+
+    public void execute() throws Exception {
+        try {
+            for (SagaCommand command : commands) {
+                command.execute();
+                executedCommands.push(command);
+            }
+        } catch (Exception ex) {
+            rollback();
+            throw ex;
+        }
+    }
+
+    private void rollback() {
+        while (!executedCommands.isEmpty()) {
+            try {
+                executedCommands.pop().compensate();
+            } catch (Exception rollbackEx) {
+                // log and continue rollback
+            }
+        }
+    }
+}

--- a/service/order/src/main/java/com/nahid/order/service/OrderItemFactory.java
+++ b/service/order/src/main/java/com/nahid/order/service/OrderItemFactory.java
@@ -1,0 +1,63 @@
+package com.nahid.order.service;
+
+import com.nahid.order.dto.request.CreateOrderItemRequest;
+import com.nahid.order.dto.response.PurchaseProductItemResultDto;
+import com.nahid.order.entity.OrderItem;
+import com.nahid.order.exception.OrderProcessingException;
+import com.nahid.order.mapper.OrderMapper;
+import com.nahid.order.util.constant.ExceptionMessageConstant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderItemFactory {
+
+    private final OrderMapper orderMapper;
+
+    public List<OrderItem> createOrderItems(
+            List<CreateOrderItemRequest> items,
+            Map<Long, PurchaseProductItemResultDto> reservedItemsMap
+    ) {
+        return items.stream()
+                .map(itemRequest -> createOrderItem(itemRequest, reservedItemsMap))
+                .toList();
+    }
+
+    private OrderItem createOrderItem(CreateOrderItemRequest itemRequest,
+                                      Map<Long, PurchaseProductItemResultDto> reservedItemsMap) {
+        Long productId = itemRequest.getProductId();
+        PurchaseProductItemResultDto reservedItem = reservedItemsMap.get(productId);
+
+        if (reservedItem == null || !reservedItem.isAvailable()) {
+            throw new OrderProcessingException(String.format(
+                    ExceptionMessageConstant.PRODUCT_RESERVATION_FAILED,
+                    "Product unavailable or not reserved: " + productId));
+        }
+
+        if (reservedItem.getPrice() == null) {
+            throw new OrderProcessingException(String.format(
+                    ExceptionMessageConstant.PRODUCT_PRICE_FETCH_FAILED,
+                    "Price missing for product: " + productId));
+        }
+
+        if (!itemRequest.getQuantity().equals(reservedItem.getRequestedQuantity())) {
+            log.warn("Quantity mismatch for product {}. Requested: {}, Reserved: {}",
+                    productId, itemRequest.getQuantity(), reservedItem.getRequestedQuantity());
+        }
+
+        OrderItem item = orderMapper.toEntity(itemRequest);
+        item.setProductName(reservedItem.getProductName());
+        item.setProductSku(reservedItem.getSku());
+        item.setUnitPrice(reservedItem.getPrice());
+        item.setTotalPrice(reservedItem.getPrice().multiply(BigDecimal.valueOf(item.getQuantity())));
+
+        return item;
+    }
+}


### PR DESCRIPTION
### Motivation

- Implement the orchestrated Order Placement Saga so the Order service acts as the deterministic orchestrator for inventory reservation and order persistence in the critical order-creation flow. 
- Provide a reusable, command-based saga template that enforces compensating logic and reverse-order rollback on failure. 
- Reduce inline orchestration complexity by extracting step logic and order-item creation into focused components to improve maintainability and testability.

### Description

- Added a lightweight saga framework: `SagaCommand` interface and `SagaManager` orchestrator that executes steps sequentially and rolls back in reverse order on failure. 
- Introduced `OrderSagaContext` to carry request-scoped data (request, orderNumber, reservation response, saved order, order items) across steps. 
- Implemented concrete commands: `ReserveProductsCommand` (reserves products and compensates by releasing), `PersistOrderCommand` (persists the order and compensates by deleting the saved order), and `ConfirmReservationCommand` (confirms reservation). 
- Refactored order item construction into `OrderItemFactory` and wired the saga into `createOrder` in `OrderServiceImpl`, replacing the previous inline reservation/persistence/rollback logic and using the saga steps to produce the final saved order and publish events.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4d18a8c88324b5a25762e37ef4ef)